### PR TITLE
added getTags() and getSafeForWork functions to client and filelink

### DIFF
--- a/examples/get-safe-for-work.php
+++ b/examples/get-safe-for-work.php
@@ -1,0 +1,32 @@
+<?php
+use Filestack\FilestackClient;
+use Filestack\FilestackSecurity;
+use Filestack\Filelink;
+use Filestack\FilestackException;
+
+$test_api_key = 'YOUR_FILESTACK_API_KEY';
+$test_secret = 'YOUR_FILESTACK_SECURITY_SECRET';
+
+$security = new FilestackSecurity($test_secret);
+$client = new FilestackClient($test_api_key, $security);
+
+$file_handle = 'bzjSo5gAT76ra25sjk4c';
+
+# get tags with client
+$result_json = $client->getSafeForWork($file_handle);
+var_dump($result_json);
+
+# get tags with filelink
+$filelink = new Filelink($file_handle,
+    $test_api_key, $security);
+
+$json_result = $filelink->getSafeForWork();
+var_dump($json_result);
+
+# example json result
+/*
+{
+  "sfw": true
+}
+*/
+

--- a/examples/image-tagging.php
+++ b/examples/image-tagging.php
@@ -1,0 +1,46 @@
+<?php
+use Filestack\FilestackClient;
+use Filestack\FilestackSecurity;
+use Filestack\Filelink;
+use Filestack\FilestackException;
+
+$test_api_key = 'YOUR_FILESTACK_API_KEY';
+$test_secret = 'YOUR_FILESTACK_SECURITY_SECRET';
+
+$security = new FilestackSecurity($test_secret);
+$client = new FilestackClient($test_api_key, $security);
+
+$file_handle = 'bzjSo5gAT76ra25sjk4c';
+
+# get tags with client
+$result_json = $client->getTags($file_handle);
+var_dump($result_json);
+
+# get tags with filelink
+$filelink = new Filelink($file_handle,
+    $test_api_key, $security);
+
+$json_result = $filelink->getTags();
+var_dump($json_result);
+
+# example json result
+/*
+{
+  "tags": {
+    "auto": {
+      "accipitriformes": 58,
+      "beak": 90,
+      "bird": 97,
+      "bird of prey": 95,
+      "fauna": 84,
+      "great grey owl": 89,
+      "hawk": 66,
+      "owl": 97,
+      "vertebrate": 92,
+      "wildlife": 81
+    },
+    "user": null
+  }
+}
+*/
+

--- a/filestack/Filelink.php
+++ b/filestack/Filelink.php
@@ -1300,6 +1300,32 @@ class Filelink
     }
 
     /**
+     * Get the sfw (safe for work) flag for this filelink
+     *
+     * @throws FilestackException   if API call fails, e.g 404 file not found
+     *
+     * @return json
+     */
+    public function getSafeForWork()
+    {
+        $result = $this->sendGetSafeForWork($this->handle, $this->security);
+        return $result;
+    }
+
+    /**
+     * Get the tags for this filelink
+     *
+     * @throws FilestackException   if API call fails, e.g 404 file not found
+     *
+     * @return json
+     */
+    public function getTags()
+    {
+        $result = $this->sendGetTags($this->handle, $this->security);
+        return $result;
+    }
+
+    /**
      * Applied array of transformation tasks to this file link.
      *
      * @param array     $transform_tasks    array of transformation tasks and

--- a/filestack/FilestackClient.php
+++ b/filestack/FilestackClient.php
@@ -100,7 +100,38 @@ class FilestackClient
 
         // call CommonMixin function
         $result = $this->sendGetMetaData($url, $fields, $this->security);
+        return $result;
+    }
 
+    /**
+     * Get sfw (safe for work) flag of a filelink
+     *
+     * @param string            $handle     Filestack filelink handle
+     *
+     * @throws FilestackException   if API call fails
+     *
+     * @return json
+     */
+    public function getSafeForWork($handle)
+    {
+        // call CommonMixin function
+        $result = $this->sendGetSafeForWork($handle, $this->security);
+        return $result;
+    }
+
+    /**
+     * Get tags of a filelink
+     *
+     * @param string            $handle     Filestack filelink handle
+     *
+     * @throws FilestackException   if API call fails
+     *
+     * @return json
+     */
+    public function getTags($handle)
+    {
+        // call CommonMixin function
+        $result = $this->sendGetTags($handle, $this->security);
         return $result;
     }
 

--- a/filestack/mixins/CommonMixin.php
+++ b/filestack/mixins/CommonMixin.php
@@ -185,6 +185,68 @@ trait CommonMixin
     }
 
     /**
+     * Get the safe for work (sfw) flag of a filelink.
+     *
+     * @param string            $handle     Filestack file handle
+     * @param FilestackSecurity $security   Filestack security object if
+     *                                      security settings is turned on
+     *
+     * @throws FilestackException   if API call fails, e.g 404 file not found
+     *
+     * @return json
+     */
+    protected function sendGetSafeForWork($handle, $security)
+    {
+        $url = sprintf('%s/sfw/security=policy:%s,signature:%s/%s',
+            FilestackConfig::CDN_URL,
+            $security->policy,
+            $security->signature,
+            $handle);
+
+        $response = $this->sendRequest('GET', $url);
+        $status_code = $response->getStatusCode();
+
+        if ($status_code !== 200) {
+            throw new FilestackException($response->getBody(), $status_code);
+        }
+
+        $json_response = json_decode($response->getBody(), true);
+
+        return $json_response;
+    }
+
+    /**
+     * Get the tags of a filelink.
+     *
+     * @param string            $handle     Filestack file handle
+     * @param FilestackSecurity $security   Filestack security object if
+     *                                      security settings is turned on
+     *
+     * @throws FilestackException   if API call fails, e.g 404 file not found
+     *
+     * @return json
+     */
+    protected function sendGetTags($handle, $security)
+    {
+        $url = sprintf('%s/tags/security=policy:%s,signature:%s/%s',
+            FilestackConfig::CDN_URL,
+            $security->policy,
+            $security->signature,
+            $handle);
+
+        $response = $this->sendRequest('GET', $url);
+        $status_code = $response->getStatusCode();
+
+        if ($status_code !== 200) {
+            throw new FilestackException($response->getBody(), $status_code);
+        }
+
+        $json_response = json_decode($response->getBody(), true);
+
+        return $json_response;
+    }
+
+    /**
      * Overwrite a file in cloud storage
      *
      * @param string            $resource   url or filepath

--- a/tests/FilelinkTest.php
+++ b/tests/FilelinkTest.php
@@ -245,6 +245,88 @@ class FilelinkTest extends BaseTest
     }
 
     /**
+     * Test getting sfw flag of a filelink
+     */
+    public function testFilelinkGetSfwSuccess()
+    {
+        $mock_response = new MockHttpResponse(
+            200,
+            '{"sfw": true}'
+        );
+
+        $stub_http_client = $this->createMock(\GuzzleHttp\Client::class);
+        $stub_http_client->method('request')
+             ->willReturn($mock_response);
+
+        $filelink = new Filelink($this->test_file_handle, $this->test_api_key,
+                        $this->test_security, $stub_http_client);
+
+        $result = $filelink->getSafeForWork();
+        $this->assertNotNull($result);
+    }
+
+    /**
+     * Test getting sfw flag of a filelink
+     */
+    public function testFilelinkGetSfwException()
+    {
+        $mock_response = new MockHttpResponse(404);
+
+        $stub_http_client = $this->createMock(\GuzzleHttp\Client::class);
+        $stub_http_client->method('request')
+             ->willReturn($mock_response);
+
+        $this->expectException(FilestackException::class);
+        $this->expectExceptionCode(404);
+
+        $filelink = new Filelink($this->test_file_handle, $this->test_api_key,
+                        $this->test_security, $stub_http_client);
+
+        $filelink->getSafeForWork();
+    }
+
+    /**
+     * Test getting tags of a filelink
+     */
+    public function testFilelinkGetTagsSuccess()
+    {
+        $mock_response = new MockHttpResponse(
+            200,
+            '{"tags": "some-tags"}'
+        );
+
+        $stub_http_client = $this->createMock(\GuzzleHttp\Client::class);
+        $stub_http_client->method('request')
+             ->willReturn($mock_response);
+
+        $filelink = new Filelink($this->test_file_handle, $this->test_api_key,
+                        $this->test_security, $stub_http_client);
+
+        $result = $filelink->getTags();
+        $this->assertNotNull($result);
+    }
+
+    /**
+     * Test getting tags of a filelink failed
+     */
+    public function testFilelinkGetTagsException()
+    {
+        $mock_response = new MockHttpResponse(404);
+
+        $stub_http_client = $this->createMock(\GuzzleHttp\Client::class);
+        $stub_http_client->method('request')
+             ->willReturn($mock_response);
+
+        $this->expectException(FilestackException::class);
+        $this->expectExceptionCode(404);
+
+        $filelink = new Filelink($this->test_file_handle, $this->test_api_key,
+                        $this->test_security, $stub_http_client);
+
+        $filelink->getTags();
+    }
+
+    /**
      * Test getMetaData throws exception for invalid file
      */
     public function testFilelinkGetMetadataException()

--- a/tests/FilestackClientTest.php
+++ b/tests/FilestackClientTest.php
@@ -93,6 +93,97 @@ class FilestackClientTest extends BaseTest
     }
 
     /**
+     * Test getting sfw (safe for work) flag of a filelink
+     */
+    public function testGetSfwSuccess()
+    {
+        $mock_response = new MockHttpResponse(
+            200,
+            '{"sfw": true}'
+        );
+
+        $stub_http_client = $this->createMock(\GuzzleHttp\Client::class);
+        $stub_http_client->method('request')
+             ->willReturn($mock_response);
+
+        $client = new FilestackClient(
+            $this->test_api_key,
+            $this->test_security,
+            $stub_http_client
+        );
+        $result_json = $client->getSafeForWork($this->test_file_handle);
+        $this->assertNotNull($result_json);
+    }
+
+    /**
+     * Test getting sfw (safe for work) failed with exception
+     */
+    public function testGetSfwException()
+    {
+        $mock_response = new MockHttpResponse(404);
+
+        $stub_http_client = $this->createMock(\GuzzleHttp\Client::class);
+        $stub_http_client->method('request')
+             ->willReturn($mock_response);
+
+        $this->expectException(FilestackException::class);
+        $this->expectExceptionCode(404);
+
+        $client = new FilestackClient(
+            $this->test_api_key,
+            $this->test_security,
+            $stub_http_client
+        );
+        $client->getSafeForWork($this->test_file_handle);
+    }
+
+    /**
+     * Test getting tags of a filelink
+     */
+    public function testGetTagsSuccess()
+    {
+        $mock_response = new MockHttpResponse(
+            200,
+            '{"tags": "sometags"}'
+        );
+
+        $stub_http_client = $this->createMock(\GuzzleHttp\Client::class);
+        $stub_http_client->method('request')
+             ->willReturn($mock_response);
+
+        $client = new FilestackClient(
+            $this->test_api_key,
+            $this->test_security,
+            $stub_http_client
+        );
+        $result_json = $client->getTags($this->test_file_handle);
+
+        $this->assertNotNull($result_json);
+    }
+
+    /**
+     * Test getting tags failed
+     */
+    public function testGetTagsException()
+    {
+        $mock_response = new MockHttpResponse(404);
+
+        $stub_http_client = $this->createMock(\GuzzleHttp\Client::class);
+        $stub_http_client->method('request')
+             ->willReturn($mock_response);
+
+        $this->expectException(FilestackException::class);
+        $this->expectExceptionCode(404);
+
+        $client = new FilestackClient(
+            $this->test_api_key,
+            $this->test_security,
+            $stub_http_client
+        );
+        $client->getTags($this->test_file_handle);
+    }
+
+    /**
      * Test getting metadata throws exception for invalid file
      */
     public function testGetMetadataException()


### PR DESCRIPTION
1. added FilestackClient.getTags() and Filelink.getTags()
2. added FilestackClient.getSafeForWork() and Filelink.getSafeForWork()