### PR TITLE
fix #35 : Add CommonMixin::addDownloadFlagToUrl() 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ coverage/
 build/*
 tests/testfiles/*
 logs/
+.idea/

--- a/filestack/mixins/CommonMixin.php
+++ b/filestack/mixins/CommonMixin.php
@@ -114,7 +114,9 @@ trait CommonMixin
         # send request
         $options = ['sink' => $destination];
 
-        $url .= '&dl=true';
+        // add download flag to url
+        $url = $this->addDownloadFlagToUrl($url);
+
         $response = $this->sendRequest('GET', $url, $options);
         $status_code = $response->getStatusCode();
 

--- a/filestack/mixins/CommonMixin.php
+++ b/filestack/mixins/CommonMixin.php
@@ -127,6 +127,16 @@ trait CommonMixin
     }
 
     /**
+     * Append the download flag to a url that may or may not have existing query string flags
+     */
+    public function addDownloadFlagToUrl($url)
+    {
+        $main_url = (string) explode('?', $url)[0];
+        $query_string = parse_url($url, PHP_URL_QUERY);
+        return $main_url.'?dl=true'.($query_string ? '&'.$query_string : '');
+    }
+
+    /**
      * Get the content of a file.
      *
      * @param string            $url        Filestack file url

--- a/tests/CommonMixinTest.php
+++ b/tests/CommonMixinTest.php
@@ -1,0 +1,25 @@
+<?php
+namespace Filestack\Tests;
+
+use Filestack\FilestackConfig;
+use Filestack\Mixins\CommonMixin;
+
+class CommonMixinTest extends \PHPUnit_Framework_TestCase
+{
+
+    function testAddDownloadFlagToUrl()
+    {
+        $mock = $this->getMockForTrait(CommonMixin::class);
+        $base_url = FilestackConfig::CDN_URL.'/some-file-handle';
+
+        // without existing query string
+        $url = $base_url;
+        $expected_url = $base_url.'?dl=true';
+        $this->assertEquals($expected_url, $mock->addDownloadFlagToUrl($url));
+
+        // with signed url query string
+        $url = $base_url.'?policy=foo&signature=bar';
+        $expected_url = $base_url.'?dl=true&policy=foo&signature=bar';
+        $this->assertEquals($expected_url, $mock->addDownloadFlagToUrl($url));
+    }
+}


### PR DESCRIPTION
… method to correctly add the download param when getting file for download.