### PR TITLE
fix #40 : Add support for custom CNAME

### DIFF
--- a/filestack/Filelink.php
+++ b/filestack/Filelink.php
@@ -1378,7 +1378,7 @@ class Filelink
      *
      */
     private function hostname() {
-        return (!is_null($this->cname)) ? 'https://' . $this->cname : FilestackConfig::CDN_URL;
+        return $this->getCustomUrl(FilestackConfig::CDN_URL);
     }
 
     /**

--- a/filestack/Filelink.php
+++ b/filestack/Filelink.php
@@ -49,9 +49,7 @@ class Filelink
         }
 
         $this->http_client = $http_client; // CommonMixin
-
-        $cname = filter_var($cname, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME);
-        $this->cname = $cname ? $cname : null;
+        $this->cname = $cname;
     }
 
     /**

--- a/filestack/Filelink.php
+++ b/filestack/Filelink.php
@@ -21,11 +21,22 @@ class Filelink
     /**
      * Filelink constructor
      *
-     * @param string    $handle     Filestack file handle
-     * @param string    $api_key    Filestack API Key
+     * @param string            $handle       Filestack file handle
+     * @param string            $api_key      Filestack API Key
+     * @param FilestackSecurity $security     Filestack security object if
+     *                                        security settings is turned on
+     * @param GuzzleHttp\Client $http_client  DI http client, will instantiate
+     *                                        one if not passed in
+     * @param string            $cname        Domain to use for all URLs.
+     *                                        __Requires the custom CNAME
+     *                                        addon__. If this is enabled then
+     *                                        you must also set up your own
+     *                                        OAuth applications for each cloud
+     *                                        source you wish to use in the
+     *                                        picker.
      */
     public function __construct($handle, $api_key = '', $security = null,
-                                $http_client = null)
+                                $http_client = null, $cname = null)
     {
         $this->handle = $handle;
         $this->api_key = $api_key;
@@ -38,6 +49,9 @@ class Filelink
         }
 
         $this->http_client = $http_client; // CommonMixin
+
+        $cname = filter_var($cname, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME);
+        $this->cname = $cname ? $cname : null;
     }
 
     /**
@@ -1360,13 +1374,23 @@ class Filelink
     }
 
     /**
+     * return the protocol and hostname for the URL, depending on custom CNAME.
+     *
+     * @return string
+     *
+     */
+    private function hostname() {
+        return (!is_null($this->cname)) ? 'https://' . $this->cname : FilestackConfig::CDN_URL;
+    }
+
+    /**
      * return the URL (cdn) of this filelink
      *
      * @return string
      */
     public function url()
     {
-        return sprintf('%s/%s', FilestackConfig::CDN_URL, $this->handle);
+        return sprintf('%s/%s', $this->hostname(), $this->handle);
     }
 
     /**
@@ -1397,7 +1421,7 @@ class Filelink
                     $this->security->signature
                 ) : '';
 
-            $this->transform_url = sprintf(FilestackConfig::CDN_URL . '%s/%s',
+            $this->transform_url = sprintf($this->hostname() . '%s/%s',
                 $security_str,
                 $this->handle);
         }

--- a/filestack/FilestackClient.php
+++ b/filestack/FilestackClient.php
@@ -70,7 +70,7 @@ class FilestackClient
      */
     public function getCdnUrl($handle)
     {
-        $url = sprintf('%s/%s', FilestackConfig::CDN_URL, $handle);
+        $url = sprintf('%s/%s', $this->getCustomUrl(FilestackConfig::CDN_URL), $handle);
         return $url;
     }
 
@@ -756,7 +756,7 @@ class FilestackClient
 
         // build endpoint url
         $url = sprintf('%s/store/%s?key=%s',
-            FilestackConfig::API_URL,
+            $this->getCustomUrl(FilestackConfig::API_URL),
             $location,
             $this->api_key);
 

--- a/filestack/FilestackClient.php
+++ b/filestack/FilestackClient.php
@@ -27,9 +27,16 @@ class FilestackClient
      * @param GuzzleHttp\Client $http_client    DI http client, will instantiate
      *                                          one if not passed in
      * @param UploadProcessor   $upload_processor DI upload_processor object
+     * @param string            $cname          Domain to use for all URLs.
+     *                                          __Requires the custom CNAME
+     *                                          addon__. If this is enabled then
+     *                                          you must also set up your own
+     *                                          OAuth applications for each
+     *                                          cloud source you wish to use in
+     *                                          the picker.
      */
     public function __construct($api_key, $security = null, $http_client = null,
-        $upload_processor = null)
+        $upload_processor = null, $cname = null)
     {
         $this->api_key = $api_key;
         $this->security = $security;
@@ -43,6 +50,9 @@ class FilestackClient
             $upload_processor = new UploadProcessor($api_key, $security, $http_client);
         }
         $this->upload_processor = $upload_processor;
+
+        $cname = filter_var($cname, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME);
+        $this->cname = $cname ? $cname : null;
     }
 
     /**

--- a/filestack/FilestackClient.php
+++ b/filestack/FilestackClient.php
@@ -50,9 +50,7 @@ class FilestackClient
             $upload_processor = new UploadProcessor($api_key, $security, $http_client);
         }
         $this->upload_processor = $upload_processor;
-
-        $cname = filter_var($cname, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME);
-        $this->cname = $cname ? $cname : null;
+        $this->cname = $cname;
     }
 
     /**

--- a/filestack/FilestackConfig.php
+++ b/filestack/FilestackConfig.php
@@ -11,6 +11,15 @@ class FilestackConfig
     const CDN_URL = 'https://cdn.filestackcontent.com';
     const UPLOAD_URL = 'https://upload.filestackapi.com';
 
+    // Custom CNAME templates. Replace __CNAME__.
+    const CNAME_NEEDLE = '__CNAME__';
+    const CNAME_TEMPLATE = array(
+      self::API_URL => 'https://www.__CNAME__/api',
+      self::PROCESS_URL => 'https://process.__CNAME__',
+      self::CDN_URL => 'https://cdn.__CNAME__',
+      self::UPLOAD_URL => 'https://upload.__CNAME__',
+    );
+
     const UPLOAD_PART_SIZE = 1024 * 1024 * 8; // last_digit=MB
     const UPLOAD_CHUNK_SIZE = 1024 * 1024 * 1; // last_digit=MB
     const UPLOAD_MIN_CHUNK_SIZE = 1024 * 32; // last_digit=KB

--- a/filestack/UploadProcessor.php
+++ b/filestack/UploadProcessor.php
@@ -80,7 +80,7 @@ class UploadProcessor
 
         $this->appendSecurity($data);
 
-        $url = FilestackConfig::UPLOAD_URL . '/multipart/start';
+        $url = $this->getCustomUrl(FilestackConfig::UPLOAD_URL) . '/multipart/start';
         $response = $this->sendRequest('POST', $url, ['multipart' => $data]);
         $json = $this->handleResponseDecodeJson($response);
 
@@ -283,7 +283,7 @@ class UploadProcessor
      */
     protected function processChunks($part, $chunks)
     {
-        $upload_url = FilestackConfig::UPLOAD_URL . '/multipart/upload';
+        $upload_url = $this->getCustomUrl(FilestackConfig::UPLOAD_URL) . '/multipart/upload';
         $max_retries = FilestackConfig::MAX_RETRIES;
 
         $num_retries = 0;
@@ -353,7 +353,7 @@ class UploadProcessor
      */
     protected function commitPart($part)
     {
-        $commit_url = FilestackConfig::UPLOAD_URL . '/multipart/commit';
+        $commit_url = $this->getCustomUrl(FilestackConfig::UPLOAD_URL) . '/multipart/commit';
         $commit_data = $this->buildCommitData($part);
 
         $response = $this->sendRequest('POST', $commit_url,
@@ -445,7 +445,7 @@ class UploadProcessor
 
         $this->appendSecurity($data);
 
-        $url = FilestackConfig::UPLOAD_URL . '/multipart/complete';
+        $url = $this->getCustomUrl(FilestackConfig::UPLOAD_URL) . '/multipart/complete';
         $response = $this->sendRequest('POST', $url, ['multipart' => $data]);
         $status_code = $response->getStatusCode();
 

--- a/filestack/mixins/CommonMixin.php
+++ b/filestack/mixins/CommonMixin.php
@@ -23,6 +23,8 @@ trait CommonMixin
     protected $user_agent_header;
     protected $source_header;
 
+    public $cname;
+
     /**
      * Check if a string is a valid url.
      *
@@ -318,7 +320,12 @@ trait CommonMixin
         $url = $json_response['url'];
         $file_handle = substr($url, strrpos($url, '/') + 1);
 
-        $filelink = new Filelink($file_handle, $this->api_key, $this->security);
+        $filelink = new Filelink(
+            $file_handle,
+            $this->api_key,
+            $this->security,
+            $this->cname
+        );
         $filelink->metadata['filename'] = $json_response['filename'];
         $filelink->metadata['size'] = $json_response['size'];
         $filelink->metadata['mimetype'] = 'unknown';

--- a/filestack/mixins/CommonMixin.php
+++ b/filestack/mixins/CommonMixin.php
@@ -34,24 +34,11 @@ trait CommonMixin
      */
     protected function getCustomUrl($url) {
       if (!is_null($this->cname)) {
-        switch ($url) {
-        case FilestackConfig::API_URL:
-          $url = "https://www.{$this->cname}/api";
-          break;
-
-        case FilestackConfig::PROCESS_URL:
-          $url = "https://process.{$this->cname}";
-          break;
-
-        case FilestackConfig::CDN_URL:
-          $url = "https://cdn.{$this->cname}";
-          break;
-
-        case FilestackConfig::UPLOAD_URL:
-          $url = "https://upload.{$this->cname}";
-          break;
-
-        }
+        $url = str_replace(
+          FilestackConfig::CNAME_NEEDLE,
+          $this->cname,
+          FilestackConfig::CNAME_TEMPLATE[$url]
+        );
       }
       return $url;
     }

--- a/filestack/mixins/CommonMixin.php
+++ b/filestack/mixins/CommonMixin.php
@@ -26,6 +26,37 @@ trait CommonMixin
     public $cname;
 
     /**
+     * If CNAME is set, return custom CNAME URL, else, noop.
+     *
+     * @param string $url
+     *
+     * @return string
+     */
+    protected function getCustomUrl($url) {
+      if (!is_null($this->cname)) {
+        switch ($url) {
+        case FilestackConfig::API_URL:
+          $url = "https://www.{$this->cname}/api";
+          break;
+
+        case FilestackConfig::PROCESS_URL:
+          $url = "https://process.{$this->cname}";
+          break;
+
+        case FilestackConfig::CDN_URL:
+          $url = "https://cdn.{$this->cname}";
+          break;
+
+        case FilestackConfig::UPLOAD_URL:
+          $url = "https://upload.{$this->cname}";
+          break;
+
+        }
+      }
+      return $url;
+    }
+
+    /**
      * Check if a string is a valid url.
      *
      * @param   string  $url    url string to check
@@ -69,7 +100,7 @@ trait CommonMixin
     public function sendDelete($handle, $api_key, $security)
     {
         $url = sprintf('%s/file/%s?key=%s',
-            FilestackConfig::API_URL, $handle, $api_key);
+            $this->getCustomUrl(FilestackConfig::API_URL), $handle, $api_key);
 
         if ($security) {
             $url = $security->signUrl($url);
@@ -214,7 +245,7 @@ trait CommonMixin
     protected function sendGetSafeForWork($handle, $security)
     {
         $url = sprintf('%s/sfw/security=policy:%s,signature:%s/%s',
-            FilestackConfig::CDN_URL,
+            $this->getCustomUrl(FilestackConfig::CDN_URL),
             $security->policy,
             $security->signature,
             $handle);
@@ -245,7 +276,7 @@ trait CommonMixin
     protected function sendGetTags($handle, $security)
     {
         $url = sprintf('%s/tags/security=policy:%s,signature:%s/%s',
-            FilestackConfig::CDN_URL,
+            $this->getCustomUrl(FilestackConfig::CDN_URL),
             $security->policy,
             $security->signature,
             $handle);
@@ -278,7 +309,7 @@ trait CommonMixin
     public function sendOverwrite($resource, $handle, $api_key, $security)
     {
         $url = sprintf('%s/file/%s?key=%s',
-            FilestackConfig::API_URL, $handle, $api_key);
+            $this->getCustomURL(FilestackConfig::API_URL), $handle, $api_key);
 
         if ($security) {
             $url = $security->signUrl($url);

--- a/filestack/mixins/TransformationMixin.php
+++ b/filestack/mixins/TransformationMixin.php
@@ -80,8 +80,8 @@ trait TransformationMixin
      */
     public function sendDebug($transform_url, $api_key, $security = null)
     {
-        $transform_str = str_replace(FilestackConfig::CDN_URL . '/', '', $transform_url);
-        $debug_url = sprintf('%s/%s/debug/%s', FilestackConfig::CDN_URL,
+        $transform_str = str_replace($this->getCustomUrl(FilestackConfig::CDN_URL) . '/', '', $transform_url);
+        $debug_url = sprintf('%s/%s/debug/%s', $this->getCustomUrl(FilestackConfig::CDN_URL),
             $api_key, $transform_str);
 
         if ($security) {
@@ -249,7 +249,8 @@ trait TransformationMixin
                                           $tasks_str, $security = null)
     {
         $api_host = $type == 'image' ?
-            FilestackConfig::CDN_URL : FilestackConfig::PROCESS_URL;
+          $this->getCustomUrl(FilestackConfig::CDN_URL) :
+          $this->getCustomUrl(FilestackConfig::PROCESS_URL);
 
         $base_url = sprintf('%s/%s',
             $api_host,

--- a/tests/BaseTest.php
+++ b/tests/BaseTest.php
@@ -7,6 +7,7 @@ use Filestack\FilestackSecurity;
 class BaseTest extends \PHPUnit_Framework_TestCase
 {
     protected $test_api_key;
+    protected $test_cname;
     protected $test_secret;
     protected $test_file_path;
     protected $test_file_url;
@@ -18,12 +19,14 @@ class BaseTest extends \PHPUnit_Framework_TestCase
     public function __construct()
     {
         $this->test_api_key = 'YOUR_FILESTACK_API_KEY';
+        $this->test_cname = 'cname.test';
         $this->test_file_handle = 'zOHgdRG4S5WikRbZNBEn';
 
         $this->test_api_key_no_sec = 'YOUR_FILESTACK_API_KEY';
         $this->test_file_handle_no_sec = 'SD20cycaQwMttDxaj4YK';
 
         $this->test_file_url = FilestackConfig::CDN_URL . '/' . $this->test_file_handle;
+        $this->test_cname_file_url = 'https://' . $this->test_cname . '/' . $this->test_file_handle;
         $this->test_secret = 'YOUR_FILESTACK_SECURITY_SECRET';
         $this->test_filepath = __DIR__ . '/testfiles/calvinandhobbes.jpg';
         $this->test_security = new FilestackSecurity($this->test_secret);

--- a/tests/FilelinkTest.php
+++ b/tests/FilelinkTest.php
@@ -18,6 +18,19 @@ class FilelinkTest extends BaseTest
     }
 
     /**
+     * Test initializing Filelink intialized with handle and API Key
+     */
+    public function testFilelinkInitializedWithCustomCname()
+    {
+        $filelink = new Filelink($this->test_file_handle, $this->test_api_key, null, null, $this->test_cname);
+        $this->assertEquals($filelink->handle, $this->test_file_handle);
+        $this->assertEquals($filelink->api_key, $this->test_api_key);
+        $this->assertEquals($filelink->cname, $this->test_cname);
+
+        return $filelink;
+    }
+
+    /**
      * Test Filelink get Signed Url
      */
     public function testFilelinkSignedUrl()
@@ -25,6 +38,22 @@ class FilelinkTest extends BaseTest
         $filelink = new Filelink($this->test_file_handle,
             $this->test_api_key);
 
+        $expected_url = sprintf('%s?policy=%s&signature=%s',
+            $filelink->url(),
+            $this->test_security->policy,
+            $this->test_security->signature
+        );
+
+        $signed_url = $filelink->signedUrl($this->test_security);
+        $this->assertEquals($expected_url, $signed_url);
+    }
+
+    /**
+     * Test Filelink get Signed Url with custom CNAME
+     * @depends testFilelinkInitializedWithCustomCname
+     */
+    public function testFilelinkSignedUrlWithCustomCname($filelink)
+    {
         $expected_url = sprintf('%s?policy=%s&signature=%s',
             $filelink->url(),
             $this->test_security->policy,

--- a/tests/FilestackClientTest.php
+++ b/tests/FilestackClientTest.php
@@ -22,6 +22,46 @@ class FilestackClientTest extends BaseTest
     }
 
     /**
+     * Test initializing FilestackClient with an API Key & custom CNAME
+     */
+    public function testClientInitializedWithCustomCname()
+    {
+        $stub_http_client = $this->createMock(\GuzzleHttp\Client::class);
+        $client = new FilestackClient(
+            $this->test_api_key,
+            null,
+            $stub_http_client,
+            null,
+            $this->test_cname
+        );
+        $this->assertInstanceOf(FilestackClient::class, $client);
+        $this->assertEquals($client->api_key, $this->test_api_key);
+        $this->assertEquals($client->cname, $this->test_cname);
+
+        return $client;
+    }
+
+    /**
+     * Test initializing FilestackClient with an API Key & custom CNAME
+     */
+    public function testClientInitializedWithCustomCnameAndSecurity()
+    {
+        $stub_http_client = $this->createMock(\GuzzleHttp\Client::class);
+        $client = new FilestackClient(
+            $this->test_api_key,
+            $this->test_security,
+            $stub_http_client,
+            null,
+            $this->test_cname
+        );
+        $this->assertInstanceOf(FilestackClient::class, $client);
+        $this->assertEquals($client->api_key, $this->test_api_key);
+        $this->assertEquals($client->cname, $this->test_cname);
+
+        return $client;
+    }
+
+    /**
      * Test getting content of Filestack file
      */
     public function testGetContentSuccess()
@@ -41,6 +81,32 @@ class FilestackClientTest extends BaseTest
             $stub_http_client
         );
         $result = $client->getContent($this->test_file_url);
+
+        $this->assertNotNull($result);
+    }
+
+    /**
+     * Test getting content of Filestack file
+     */
+    public function testGetContentSuccessWithCustomCname()
+    {
+        $mock_response = new MockHttpResponse(
+            200,
+            new MockHttpResponseBody('some content')
+        );
+
+        $stub_http_client = $this->createMock(\GuzzleHttp\Client::class);
+        $stub_http_client->method('request')
+             ->willReturn($mock_response);
+
+        $client = new FilestackClient(
+            $this->test_api_key,
+            null,
+            $stub_http_client,
+            null,
+            $this->test_cname
+        );
+        $result = $client->getContent($this->test_cname_file_url);
 
         $this->assertNotNull($result);
     }


### PR DESCRIPTION
This patch primarily addresses the lack of custom CNAME support for urls
that might get used in HTML templates populated by a server, so that
client browsers will request resources via the custom CNAME.

This patch DOES NOT try convert all server-side requests to use the
custom CNAME as we assume that the server running this API client will
not have issues communicating with Filestack servers directly.